### PR TITLE
IGNORE_CVES, CVE_PRODUCT and CVE_VERSION do not work

### DIFF
--- a/scripts/buildroot.py
+++ b/scripts/buildroot.py
@@ -81,10 +81,10 @@ br2_pkg_var_list = [
     'builddir',
     'is-virtual',
     'license',
-    'version',
     'cve-product',
     'cve-version',
     'ignore-cves',
+    'version',
     'rawname',
     'srcdir'
 ]


### PR DESCRIPTION
The issue is that -version need to be checked after -cve-version, otherwise -version always wins and creates bogus packages as <package-name>-cve

Support issue 59508