### PR TITLE
feat: can return error on missing hashfiles or Config.in

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -318,5 +318,16 @@ config VIGILES_GENERATE_SBOM_ONLY
     help
       This option will only generate SBOM locally. 
 
-endif
+config VIGILES_REQUIRE_ALL_CONFIGS
+    bool "Require all config files"
+    default n
+    help
+      Throw an error if config.in files are missing.
 
+config VIGILES_REQUIRE_ALL_HASFILES
+    bool "Require all hashfiles"
+    default n
+    help
+      Throw an error if hashfiles are missing.
+
+endif

--- a/external.mk
+++ b/external.mk
@@ -109,6 +109,14 @@ ifeq ($(VIGILES_GENERATE_SBOM_ONLY),y)
 vigiles-opts    += -M
 endif
 
+ifeq ($(VIGILES_REQUIRE_ALL_CONFIGS),y)
+vigiles-opts    += -c
+endif
+
+ifeq ($(VIGILES_REQUIRE_ALL_HASFILES),y)
+vigiles-opts    += -i
+endif
+
 
 ifeq ($(BR2_EXTERNAL_TIMESYS_VIGILES),y)
 vigiles-check: target-finalize

--- a/scripts/packages.py
+++ b/scripts/packages.py
@@ -375,6 +375,7 @@ def get_package_dependencies(vgls, packages):
         warn("Config.in not found for packages: %s" % list(missing_configs))
 
     vgls['packages'] = pkg_dict
+    vgls['missing_configs'] = missing_configs
 
 
 def _get_pkg_hash_map(vgls):
@@ -428,4 +429,7 @@ def get_checksum_info(vgls):
 
     if missing_hashfiles:
         warn(".hash files not found for packages: %s" % missing_hashfiles)
+
+        vgls['missing_hashfiles'] = missing_hashfiles
+
     return vgls['packages']

--- a/scripts/vigiles-buildroot.py
+++ b/scripts/vigiles-buildroot.py
@@ -98,6 +98,12 @@ def parse_args():
     parser.add_argument('-v', '--include-virtual', dest='include_virtual_pkgs',
                         help='Include virtual packages in generated SBOM',
                         action='store_true')
+    parser.add_argument('-c', '--require-all-configs', dest='require_all_configs',
+                        help='Throw an error on missing Config.in',
+                        action='store_true')
+    parser.add_argument('-i', '--require-all-hashfiles', dest='require_all_hashfiles',
+                        help='Throw an error on missing hashfiles',
+                        action='store_true')
     args = parser.parse_args()
 
     set_debug(args.debug)
@@ -127,7 +133,9 @@ def parse_args():
         'llkey': args.llkey.strip() if args.llkey else '',
         'lldashboard': args.lldashboard.strip() if args.lldashboard else '',
         'upload_only': args.upload_only,
-        'include_virtual_pkgs': args.include_virtual_pkgs
+        'include_virtual_pkgs': args.include_virtual_pkgs,
+        'require_all_configs': args.require_all_configs,
+        'require_all_hashfiles': args.require_all_hashfiles
     }
 
     if not vgls.get('odir', None):
@@ -143,7 +151,7 @@ def parse_args():
 
 def collect_metadata(vgls):
     vgls["all_pkg_make_info"] = get_all_pkg_make_info(vgls["odir"])
-    
+
     dbg("Getting Config Info ...")
     vgls['config'] = get_config_options(vgls)
     if not vgls['config']:
@@ -212,5 +220,10 @@ def __main__():
     if vgls['do_check']:
         run_check(vgls)
 
+    if vgls['require_all_configs'] and vgls['missing_configs']:
+        sys.exit(1)
+
+    if vgls['require_all_hashfiles'] and vgls['missing_hashfiles']:
+        sys.exit(1)
 
 __main__()


### PR DESCRIPTION
Hi,

We would like to run Vigiles in CI and return an error code when missing Config.in or hashfiles. It is not part of Vigiles itself and more something related to Buildroot but since we want to do a proper scan and the python Vigiles already scanned the package, I thought it would be relevant.

With this change, one can pass directly in the python script arguments to throw an error when missing a hashfile and/or a Config.in. I also added 2 buildroot options which disable this option by default, which does not change the current behaviour.

I have tested this change and the make command returns an error as expected. What do you think? Thanks