### PR TITLE
feat: get update in version tag

### DIFF
--- a/scripts/buildroot.py
+++ b/scripts/buildroot.py
@@ -397,7 +397,8 @@ def _fixup_make_info(vgls):
                     warn("Invalid Source override path given for package %s: %s" % (name, override_srcdir))
                 del pdict['override-srcdir']
             else:
-                pdict['cve-version'] = cpe_version
+                update = pdict.get('cpe-id-update', '')
+                pdict['cve-version'] = f"{cpe_version}{update}"
 
     for current, needed in rawname_fixups.items():
         pkg_dict[needed] = pkg_dict.pop(current, {})
@@ -413,7 +414,8 @@ def _fixup_make_info(vgls):
         if 'cve-product' not in pdict:
             pkg_dict[name]['cve-product'] = name
         if not pdict.get('cve-version', ''):
-            pkg_dict[name]['cve-version'] = pdict['version']
+            update = pdict[name].get('cpe-id-update', '')
+            pkg_dict[name]['cve-version'] = f"{pdict['version']}{update}"
         if pdict.get('pkg-cpe-id', ''):
             pkg_dict[name]['cpe-id'] = pdict['pkg-cpe-id']
             del pkg_dict[name]['pkg-cpe-id']


### PR DESCRIPTION
Connected to ticket 61439

There are packages which have CVEs only on versions superior to a patch number. This is for example the case of [CVE-2015-7853](https://nvd.nist.gov/vuln/detail/cve-2015-7853):

> "The datalen parameter in the refclock driver in NTP 4.2.x before 4.2.8p4, and 4.3.x before 4.3.77 allows remote attackers to execute arbitrary code or cause a denial of service (crash) via a negative input value."

Currently, the variable <PACKAGE_NAME>_CPE_ID_UPDATE is not used when creating a report but some packages require to get the patch number of the package. This means Vigiles will record a version, for example 4.2.8 (ambiguous version, maybe the CVE affects it if it's 4.2.8p2 but not if superior to p4) instead of 4.2.8p18 (the CVE doesn't affect it)

Note that this variable is not always present in a package file.

This patch helps to record the variable which will help detect the patch and match the CVE more accurately properly instead